### PR TITLE
upgrade to docker-client:4.0.8

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -19,7 +19,7 @@
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
       <classifier>shaded</classifier>
-      <version>3.6.4</version>
+      <version>4.0.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
@@ -20,13 +20,13 @@
 
 package com.spotify.plugin.dockerfile;
 
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerCertificateException;
+
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Files;
-
-import com.spotify.docker.client.DefaultDockerClient;
-import com.spotify.docker.client.DockerCertificateException;
-import com.spotify.docker.client.DockerClient;
 
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -21,7 +21,7 @@
 package com.spotify.plugin.dockerfile;
 
 import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.DockerException;
+import com.spotify.docker.client.exceptions.DockerException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/LoggingProgressHandler.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/LoggingProgressHandler.java
@@ -20,12 +20,12 @@
 
 package com.spotify.plugin.dockerfile;
 
+import com.spotify.docker.client.ProgressHandler;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.ProgressMessage;
+
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
-
-import com.spotify.docker.client.DockerException;
-import com.spotify.docker.client.ProgressHandler;
-import com.spotify.docker.client.messages.ProgressMessage;
 
 import org.apache.maven.plugin.logging.Log;
 

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/PushMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/PushMojo.java
@@ -21,7 +21,7 @@
 package com.spotify.plugin.dockerfile;
 
 import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.DockerException;
+import com.spotify.docker.client.exceptions.DockerException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/TagMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/TagMojo.java
@@ -21,7 +21,7 @@
 package com.spotify.plugin.dockerfile;
 
 import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.DockerException;
+import com.spotify.docker.client.exceptions.DockerException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;


### PR DESCRIPTION
This latest version of docker-client includes a change in the
`DefaultDockerClient.fromEnv()` so that on OS X it uses
`unix:///var/run/docker.sock` by default if DOCKER_HOST is not set (to
work with Docker for Mac out of the box).

In 4.x of the docker-client the package names of exception classes
changed as well.