### PR TITLE
WIP: adds support for pushing to GCR via `mvn deploy`. Has failing in…

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -14,12 +14,27 @@
   <name>Dockerfile Maven Plugin</name>
   <description>Adds support for building Dockerfiles in Maven</description>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>2.0.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
       <classifier>shaded</classifier>
-      <version>4.0.8</version>
+      <version>8.6.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>0.6.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
…tegration test.

Hey @dflemstr, I'm trying to figure out how to debug the failing integration test. I've tried variations of `mvn -Dmaven.failsafe.debug failsafe:integration-test` without any success. I also can't figure out how to run these tests via IntelliJ. It'd be awesome if you could help me figure out the failing test, or just fix it if you happen to know what the problem is. Thanks!