### PR TITLE
fix MainIT to work on Docker for Mac

### DIFF
--- a/plugin/src/it/advanced/frontend/src/test/java/com/spotify/it/frontend/MainIT.java
+++ b/plugin/src/it/advanced/frontend/src/test/java/com/spotify/it/frontend/MainIT.java
@@ -26,6 +26,7 @@ import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.common.net.HostAndPort;
 
+import com.spotify.helios.common.descriptors.HealthCheck;
 import com.spotify.helios.testing.HeliosDeploymentResource;
 import com.spotify.helios.testing.HeliosSoloDeployment;
 import com.spotify.helios.testing.TemporaryJob;
@@ -76,6 +77,11 @@ public class MainIT {
             Resources.getResource("META-INF/docker/com.spotify.it/backend/image-name"),
             Charsets.UTF_8).trim())
         .port("http", 1337)
+        .healthCheck(HealthCheck.newHttpHealthCheck()
+            .setPath("/api/version")
+            .setPort("http")
+            .build()
+        )
         .deploy();
     HostAndPort backendAddress = backendJob.address("http");
     backend = httpUri(backendAddress);
@@ -85,6 +91,11 @@ public class MainIT {
                                    Charsets.UTF_8))
         .command(backend.toString())
         .port("http", 1338)
+        .healthCheck(HealthCheck.newHttpHealthCheck()
+            .setPath("/")
+            .setPort("http")
+            .build()
+        )
         .deploy();
     HostAndPort frontendAddress = frontendJob.address("http");
     frontend = httpUri(frontendAddress);


### PR DESCRIPTION
need to add a healthcheck to the TemporaryJob to avoid helios-testing
from thinking that the job is immediately available after the deploy
finishes.

see:
https://github.com/spotify/dockerfile-maven/pull/13#issuecomment-305355177
https://github.com/spotify/helios/issues/916#issuecomment-221090878