### PR TITLE
support for loading Google credentials from environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,20 @@ service-b:
 
 Now, `docker-compose up` and `docker-compose build` will work as
 expected.
+
+## Authentication and private Docker registry support
+
+Since version 1.3.0, the plugin will automatically use any configuration in
+your `~/.dockercfg` or `~/.docker/config.json` file when pulling, pushing, or
+building images to private registries.
+
+Additionally the plugin will enable support for Google Container Registry if it
+is able to successfully load [Google's "Application Default Credentials"][ADC].
+The plugin will also load Google credentials from the file pointed to by the
+environment variable `DOCKER_GOOGLE_CREDENTIALS` if it is defined. Since GCR
+authentication requires retrieving short-lived access codes for the given
+credentials, support for this registry is baked into the underlying
+docker-client rather than having to first populate the docker config file
+before running the plugin.
+
+[ADC]: https://developers.google.com/identity/protocols/application-default-credentials

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dockerfile-maven</artifactId>
     <groupId>com.spotify</groupId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dockerfile-maven-extension</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>dockerfile-maven</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dockerfile-maven-plugin</artifactId>
@@ -29,7 +29,7 @@
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
       <classifier>shaded</classifier>
-      <version>8.6.2</version>
+      <version>8.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>dockerfile-maven-extension</artifactId>
-      <version>1.2.3-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -29,7 +29,7 @@
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
       <classifier>shaded</classifier>
-      <version>8.7.0</version>
+      <version>8.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>dockerfile-maven</artifactId>
-  <version>1.2.3-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Dockerfile Maven Support</name>


### PR DESCRIPTION
Adds support for loading Google credentials from the environment variable DOCKER_GOOGLE_CREDENTIALS if it is set and points to a readable file.

If not set, then the Google Application Default Credentials are still used as before (if they can be loaded).

This PR also includes a change to use authentication info from the docker-cli config file, which in turn depends on some not-yet-released changes in docker-client (see https://github.com/spotify/docker-client/pull/775). This will resolve a number of open issues in this repository around a lack of authentication support.

The build will fail until https://github.com/spotify/docker-client/pull/775 is complete and released, but I wanted to create the PR now to start the review process.

In the cases where Google credentials are available, use those with higher precedence than the config file.