### PR TITLE
Add support for supplying build-args, fixes #22

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -14,6 +14,10 @@
   <name>Dockerfile Maven Plugin</name>
   <description>Adds support for building Dockerfiles in Maven</description>
 
+  <properties>
+    <docker-client.version>8.8.0</docker-client.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -29,7 +33,7 @@
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
       <classifier>shaded</classifier>
-      <version>8.8.0</version>
+      <version>${docker-client.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
@@ -62,6 +66,12 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
       <version>3.0.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.0</version>
     </dependency>
 
     <dependency>
@@ -125,6 +135,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <version>1.9</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-client</artifactId>
+            <version>${docker-client.version}</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <pomIncludes>

--- a/plugin/src/it/basic-with-build-args/Dockerfile
+++ b/plugin/src/it/basic-with-build-args/Dockerfile
@@ -1,0 +1,6 @@
+FROM scratch
+MAINTAINER David Flemström <dflemstr@spotify.com>
+
+ARG IMAGE_VERSION
+
+LABEL version=${IMAGE_VERSION}

--- a/plugin/src/it/basic-with-build-args/pom.xml
+++ b/plugin/src/it/basic-with-build-args/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -/-/-
+  Dockerfile Maven Plugin
+  %%
+  Copyright (C) 2015 - 2016 Spotify AB
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -\-\-
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spotify.it</groupId>
+  <artifactId>basic-with-build-args</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple IT verifying a basic use case with build arguments.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <buildArgs>
+                <IMAGE_VERSION>0.0.1</IMAGE_VERSION>
+              </buildArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin/src/it/basic-with-build-args/verify.groovy
+++ b/plugin/src/it/basic-with-build-args/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * -/-/-
+ * Dockerfile Maven Plugin
+ * %%
+ * Copyright (C) 2015 - 2016 Spotify AB
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -\-\-
+ */
+import com.spotify.docker.client.DefaultDockerClient
+
+File imageIdFile = new File(basedir, "target/docker/image-id")
+String imageId = imageIdFile.text.replaceAll("\\s", "")
+
+DefaultDockerClient dockerClient = DefaultDockerClient.fromEnv().build()
+imageInfo = dockerClient.inspectImage(imageId)
+
+assert imageInfo.config().labels().get("version") == "0.0.1"

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -20,12 +20,16 @@
 
 package com.spotify.plugin.dockerfile;
 
+import com.google.gson.Gson;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.DockerException;
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -82,6 +86,12 @@ public class BuildMojo extends AbstractDockerMojo {
   @Parameter(property = "dockerfile.build.noCache", defaultValue = "false")
   private boolean noCache;
 
+  /**
+   * Custom build arguments
+   */
+  @Parameter(property = "dockerfile.buildArgs")
+  private Map<String,String> buildArgs;
+
   @Override
   public void execute(DockerClient dockerClient)
       throws MojoExecutionException, MojoFailureException {
@@ -93,7 +103,7 @@ public class BuildMojo extends AbstractDockerMojo {
     }
 
     final String imageId = buildImage(
-        dockerClient, log, verbose, contextDirectory, repository, tag, pullNewerImage, noCache);
+        dockerClient, log, verbose, contextDirectory, repository, tag, pullNewerImage, noCache, buildArgs);
 
     if (imageId == null) {
       log.warn("Docker build was successful, but no image was built");
@@ -124,7 +134,8 @@ public class BuildMojo extends AbstractDockerMojo {
                            @Nullable String repository,
                            @Nonnull String tag,
                            boolean pullNewerImage,
-                           boolean noCache)
+                           boolean noCache,
+                           @Nullable Map<String,String> buildArgs)
       throws MojoExecutionException, MojoFailureException {
 
     log.info(MessageFormat.format("Building Docker context {0}", contextDirectory));
@@ -143,6 +154,15 @@ public class BuildMojo extends AbstractDockerMojo {
     }
     if (noCache) {
       buildParameters.add(DockerClient.BuildParam.noCache());
+    }
+
+    if (buildArgs != null && !buildArgs.isEmpty()) {
+      try {
+        final String encodedBuildArgs = URLEncoder.encode(new Gson().toJson(buildArgs), "utf-8");
+        buildParameters.add(new DockerClient.BuildParam("buildargs", encodedBuildArgs));
+      } catch (UnsupportedEncodingException e) {
+         throw new MojoExecutionException("Could not build image", e);
+      }
     }
 
     final DockerClient.BuildParam[] buildParametersArray =


### PR DESCRIPTION
This fixes issue #22. I took inspiration from the comments there and used the format below, let me know if you prefer another format.
```xml
<configuration>
  <buildArgs>
    <key>value</key>
  </buildArgs>
</configuration>
```