### PR TITLE
allow disabling of Google Container Registry credential checks

### DIFF
--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
@@ -192,10 +192,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
   private JarArchiver jarArchiver;
 
   /**
-   * Allows enabling/disabling gcr credentials
+   * Allows disabling of Google Container Registry authentication support. The support is enabled by
+   * default, and should be a no-op (and fail fast) in most non-GCR environments, but this behavior
+   * can be explicitly disabled with this property if needed.
    */
-  @Parameter(defaultValue = "true", property = "dockerfile.googleregistry")
-  private boolean googleregistry;
+  @Parameter(defaultValue = "true", property = "dockerfile.googleContainerRegistryEnabled")
+  private boolean googleContainerRegistryEnabled = true;
 
   /**
    * The Maven project helper.
@@ -407,7 +409,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     final List<RegistryAuthSupplier> suppliers = new ArrayList<>();
     suppliers.add(new ConfigFileRegistryAuthSupplier());
 
-    if ( googleregistry ){
+    if (googleContainerRegistryEnabled){
        try {
          final RegistryAuthSupplier googleSupplier = googleContainerRegistryAuthSupplier();
          if (googleSupplier != null) {
@@ -416,6 +418,8 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
        } catch (IOException ex) {
          getLog().info("ignoring exception while loading Google credentials", ex);
        }
+    } else {
+      getLog().info("Google Container Registry support is disabled");
     }
 
     return new MultiRegistryAuthSupplier(suppliers);

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
@@ -197,7 +197,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
    * can be explicitly disabled with this property if needed.
    */
   @Parameter(defaultValue = "true", property = "dockerfile.googleContainerRegistryEnabled")
-  private boolean googleContainerRegistryEnabled = true;
+  private boolean googleContainerRegistryEnabled;
 
   /**
    * The Maven project helper.
@@ -409,15 +409,15 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     final List<RegistryAuthSupplier> suppliers = new ArrayList<>();
     suppliers.add(new ConfigFileRegistryAuthSupplier());
 
-    if (googleContainerRegistryEnabled){
-       try {
-         final RegistryAuthSupplier googleSupplier = googleContainerRegistryAuthSupplier();
-         if (googleSupplier != null) {
-           suppliers.add(0, googleSupplier);
-         }
-       } catch (IOException ex) {
-         getLog().info("ignoring exception while loading Google credentials", ex);
-       }
+    if (googleContainerRegistryEnabled) {
+      try {
+        final RegistryAuthSupplier googleSupplier = googleContainerRegistryAuthSupplier();
+        if (googleSupplier != null) {
+          suppliers.add(0, googleSupplier);
+        }
+      } catch (IOException ex) {
+        getLog().info("Ignoring exception while loading Google credentials", ex);
+      }
     } else {
       getLog().info("Google Container Registry support is disabled");
     }


### PR DESCRIPTION
This is a continuation of #35; I added a commit addressing my own feedback to be able to merge and release this quicker.