### PR TITLE
Fixed a small typo in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ which also greatly speeds up builds.
 You no longer have to say something like:
 
     mvn package
-    mvn docker:build
+    mvn dockerfile:build
     mvn verify
-    mvn docker:push
+    mvn dockerfile:push
     mvn deploy
 
 Instead, it is simply enough to say:


### PR DESCRIPTION
I think there are two small typos in the README file. Maybe caused by copy and paste from [Docker Maven Plugin](https://github.com/spotify/docker-maven-plugin#usage).