### PR TITLE
Add a flag to tag -SNAPSHOT builds as 'latest'

### DIFF
--- a/plugin/src/it/snapshot-latest/Dockerfile
+++ b/plugin/src/it/snapshot-latest/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+MAINTAINER David Flemström <dflemstr@spotify.com>

--- a/plugin/src/it/snapshot-latest/pom.xml
+++ b/plugin/src/it/snapshot-latest/pom.xml
@@ -46,7 +46,7 @@
               <goal>build</goal>
             </goals>
             <configuration>
-              <repository>test/build-into-tag</repository>
+              <repository>test/snapshot-latest</repository>
               <tag>${project.version}</tag>
               <tagSnapshotAsLatest>true</tagSnapshotAsLatest>
             </configuration>

--- a/plugin/src/it/snapshot-latest/pom.xml
+++ b/plugin/src/it/snapshot-latest/pom.xml
@@ -24,10 +24,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.spotify.it</groupId>
-  <artifactId>build-into-tag</artifactId>
+  <artifactId>snapshot-latest</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <description>The Dockerfile is built into a repository with a custom tag</description>
+  <description>The Dockerfile is built into a repository with a a tag based on version as 'latest'</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/plugin/src/it/snapshot-latest/pom.xml
+++ b/plugin/src/it/snapshot-latest/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -/-/-
+  Dockerfile Maven Plugin
+  %%
+  Copyright (C) 2015 - 2016 Spotify AB
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -\-\-
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spotify.it</groupId>
+  <artifactId>build-into-tag</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>The Dockerfile is built into a repository with a custom tag</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <repository>test/build-into-tag</repository>
+              <tag>${project.version}</tag>
+              <tagSnapshotAsLatest>true</tagSnapshotAsLatest>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin/src/it/snapshot-latest/verify.groovy
+++ b/plugin/src/it/snapshot-latest/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * -/-/-
+ * Dockerfile Maven Plugin
+ * %%
+ * Copyright (C) 2015 - 2016 Spotify AB
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -\-\-
+ */
+File imageIdFile = new File(basedir, "target/docker/image-id")
+assert imageIdFile.isFile()
+
+File repositoryFile = new File(basedir, "target/docker/repository")
+assert repositoryFile.text == "test/build-into-tag\n"
+
+File tagFile = new File(basedir, "target/docker/tag")
+assert tagFile.text == "latest\n"
+
+File imageNameFile = new File(basedir, "target/docker/image-name")
+assert imageNameFile.text == "test/build-into-tag:latest\n"

--- a/plugin/src/it/snapshot-latest/verify.groovy
+++ b/plugin/src/it/snapshot-latest/verify.groovy
@@ -21,10 +21,10 @@ File imageIdFile = new File(basedir, "target/docker/image-id")
 assert imageIdFile.isFile()
 
 File repositoryFile = new File(basedir, "target/docker/repository")
-assert repositoryFile.text == "test/build-into-tag\n"
+assert repositoryFile.text == "test/snapshot-latest\n"
 
 File tagFile = new File(basedir, "target/docker/tag")
 assert tagFile.text == "latest\n"
 
 File imageNameFile = new File(basedir, "target/docker/image-name")
-assert imageNameFile.text == "test/build-into-tag:latest\n"
+assert imageNameFile.text == "test/snapshot-latest:latest\n"

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -23,15 +23,6 @@ package com.spotify.plugin.dockerfile;
 import com.google.gson.Gson;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.DockerException;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -39,6 +30,14 @@ import java.net.URLEncoder;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 @Mojo(name = "build",
     defaultPhase = LifecyclePhase.PACKAGE,


### PR DESCRIPTION
Defaults to false so shouldn't break any existing users, but means we tag released maven versions with their version number, but any '-SNAPSHOT' versions map to 'latest' in docker.