### PR TITLE
Make tagging around project versions more flexible

### DIFF
--- a/plugin/src/it/release-latest/Dockerfile
+++ b/plugin/src/it/release-latest/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+MAINTAINER David Flemström <dflemstr@spotify.com>

--- a/plugin/src/it/release-latest/pom.xml
+++ b/plugin/src/it/release-latest/pom.xml
@@ -24,10 +24,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.spotify.it</groupId>
-  <artifactId>snapshot-latest</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <artifactId>release-latest</artifactId>
+  <version>1.0</version>
 
-  <description>The Dockerfile is built into a repository with a tag based on a snapshot version as 'unstable'</description>
+  <description>The Dockerfile is built into a repository with a tag based on a snapshot version as 'latest'</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -46,9 +46,9 @@
               <goal>build</goal>
             </goals>
             <configuration>
-              <repository>test/snapshot-latest</repository>
+              <repository>test/release-latest</repository>
               <tag>${project.version}</tag>
-              <snapShotTag>unstable</snapShotTag>
+              <tagReleaseAsLatest>true</tagReleaseAsLatest>
             </configuration>
           </execution>
         </executions>

--- a/plugin/src/it/release-latest/verify.groovy
+++ b/plugin/src/it/release-latest/verify.groovy
@@ -21,10 +21,14 @@ File imageIdFile = new File(basedir, "target/docker/image-id")
 assert imageIdFile.isFile()
 
 File repositoryFile = new File(basedir, "target/docker/repository")
-assert repositoryFile.text == "test/snapshot-latest\n"
+assert repositoryFile.text == "test/release-latest\n"
 
 File tagFile = new File(basedir, "target/docker/tag")
-assert tagFile.text == "unstable\n"
+assert tagFile.text == "1.0\n"
+
+File alternativeTagFile = new File(basedir, "target/docker/alternative-tag")
+assert alternativeTagFile.isFile();
+assert alternativeTagFile.text == "latest\n"
 
 File imageNameFile = new File(basedir, "target/docker/image-name")
-assert imageNameFile.text == "test/snapshot-latest:unstable\n"
+assert imageNameFile.text == "test/release-latest:1.0\n"

--- a/plugin/src/it/snapshot-latest/Dockerfile
+++ b/plugin/src/it/snapshot-latest/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+MAINTAINER David Flemström <dflemstr@spotify.com>

--- a/plugin/src/it/snapshot-latest/pom.xml
+++ b/plugin/src/it/snapshot-latest/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -/-/-
+  Dockerfile Maven Plugin
+  %%
+  Copyright (C) 2015 - 2016 Spotify AB
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -\-\-
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spotify.it</groupId>
+  <artifactId>snapshot-latest</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>The Dockerfile is built into a repository with a a tag based on version as 'latest'</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <repository>test/snapshot-latest</repository>
+              <tag>${project.version}</tag>
+              <tagSnapshotAsLatest>true</tagSnapshotAsLatest>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin/src/it/snapshot-latest/pom.xml
+++ b/plugin/src/it/snapshot-latest/pom.xml
@@ -27,7 +27,7 @@
   <artifactId>snapshot-latest</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <description>The Dockerfile is built into a repository with a a tag based on version as 'latest'</description>
+  <description>The Dockerfile is built into a repository with a tag based on a snapshot version as 'latest'</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/plugin/src/it/snapshot-latest/verify.groovy
+++ b/plugin/src/it/snapshot-latest/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * -/-/-
+ * Dockerfile Maven Plugin
+ * %%
+ * Copyright (C) 2015 - 2016 Spotify AB
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -\-\-
+ */
+File imageIdFile = new File(basedir, "target/docker/image-id")
+assert imageIdFile.isFile()
+
+File repositoryFile = new File(basedir, "target/docker/repository")
+assert repositoryFile.text == "test/snapshot-latest\n"
+
+File tagFile = new File(basedir, "target/docker/tag")
+assert tagFile.text == "latest\n"
+
+File imageNameFile = new File(basedir, "target/docker/image-name")
+assert imageNameFile.text == "test/snapshot-latest:latest\n"

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
@@ -60,7 +60,8 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     IMAGE_ID("image ID", "image-id"),
     REPOSITORY("repository", "repository"),
     TAG("tag", "tag"),
-    IMAGE_NAME("image name", "image-name");
+    IMAGE_NAME("image name", "image-name"),
+    ALTERNATIVE_TAG("alternative tag", "alternative-tag");
 
     private final String friendlyName;
     private final String fileName;

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -68,6 +68,9 @@ public class BuildMojo extends AbstractDockerMojo {
   @Parameter(property = "dockerfile.tag", defaultValue = "latest")
   private String tag;
 
+  @Parameter(property = "dockerfile.tagSnapshotAsLatest", defaultValue = "false")
+  private boolean tagSnapshotAsLatest;
+
   /**
    * Disables the build goal; it becomes a no-op.
    */
@@ -100,6 +103,11 @@ public class BuildMojo extends AbstractDockerMojo {
     if (skipBuild) {
       log.info("Skipping execution because 'dockerfile.build.skip' is set");
       return;
+    }
+
+    if ( tagSnapshotAsLatest ) {
+      tag = tag.endsWith("-SNAPSHOT") ? "latest" : tag;
+      log.info(MessageFormat.format("Setting tag to: {0}", tag));
     }
 
     final String imageId = buildImage(

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/PushMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/PushMojo.java
@@ -89,5 +89,15 @@ public class PushMojo extends AbstractDockerMojo {
     } catch (DockerException | InterruptedException e) {
       throw new MojoExecutionException("Could not push image", e);
     }
+
+    final String alternativeTag = readMetadata(Metadata.ALTERNATIVE_TAG);
+    if ( alternativeTag != null ) {
+      try {
+        dockerClient.push(formatImageName(repository, alternativeTag),
+                          LoggingProgressHandler.forLog(log, verbose));
+      } catch (DockerException | InterruptedException e) {
+        throw new MojoExecutionException("Could not push image", e);
+      }
+    }
   }
 }


### PR DESCRIPTION
* Add an additional parameter to tag snapshot versions of projects built into docker images as a separate tag e.g. `unstable`
* Make it possible to tag release versions as both their version number and `latest`