### PR TITLE
Fix snapshot deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 install: true # This runs the "true" command in the install phase; thus skipping install
 script:
   - |
-    if [[ "$TRAVIS_BRANCH" == master && "$TRAVIS_PULL_REQUEST" == false && "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]
+    if [[ "$TRAVIS_BRANCH" == master && "$TRAVIS_PULL_REQUEST" == false && "$TRAVIS_JDK_VERSION" == "openjdk8" ]]
     then mvn deploy -s travis-settings.xml
     else mvn verify
     fi


### PR DESCRIPTION
When the build was moved to use openjdk instead of oraclejdk, it broke snapshot deployment due to the `$TRAVIS_JDK_VERSION` clause.