### PR TITLE
[FIX] Changing order of <configuration> tag.

### DIFF
--- a/plugin/src/it/advanced/backend/pom.xml
+++ b/plugin/src/it/advanced/backend/pom.xml
@@ -98,11 +98,11 @@
             <goals>
               <goal>build</goal>
             </goals>
-            <configuration>
-              <repository>spotify/dockerfile-advanced-backend</repository>
-            </configuration>
           </execution>
         </executions>
+        <configuration>
+          <repository>spotify/dockerfile-advanced-backend</repository>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
According to the docs, the `<configuration>` should be added after `<executions>` tag:
Here's some working example:    
```xml
<plugin>
                <groupId>com.spotify</groupId>
                <artifactId>dockerfile-maven-plugin</artifactId>
                <version>${dockerfile-maven-version}</version>
                <executions>
                    <execution>
                        <id>default</id>
                        <phase>install</phase>
                        <goals>
                            <goal>build</goal>
                        </goals>
                    </execution>
                </executions>
                <configuration>
                    <repository>${docker.image.prefix}/${project.artifactId}</repository>
                    <tag>${project.version}</tag>
                    <verbose>true</verbose>
                </configuration>
</plugin>
```