### PR TITLE
Add skip option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,19 @@ Then, in your maven settings file, add configuration for the server:
 ```
 
 exactly as you would for any other server configuration.
+
+## Skip Docker Goals Bound to Maven Phases
+
+You can pass options to maven to disable the docker goals.
+
+| Maven Option        | What Does _that thing_ Do?           |
+| ------------- |:-------------:|
+| dockerfile.skip | Disables the entire dockerfile plugin; all goals become no-ops. |
+| dockerfile.build.skip | Disables the build goal; it becomes a no-op. |
+| dockerfile.tag.skip | Disables the tag goal; it becomes a no-op. |
+| dockerfile.push.skip | Disables the push goal; it becomes a no-op. |
+
+For example to skip the entire dockerfile plugin:
+```
+mvn clean package -Ddockerfile.skip
+```


### PR DESCRIPTION
### Summary
Provides documentation on skip options
Closes #103

### Description

Sometimes in a single project where we use this plugin we support two workflows:

+ Locally,  a developer will have `mvn package` driving the docker image building based on the `Dockerfile`
+ In continuous integration builds we use a multi-stage Dockerfile and have docker driving maven with `docker build -f Dockerfile.multistage .`

We found the undocumented skip properties very helpful for letting both workflows be supported in the same project, but they deserve documentation in the readme. This pull request provides that documentation. Thank you for your excellent work!