### PR TITLE
Security Upgrade: docker-client

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -15,7 +15,7 @@
   <description>Adds support for building Dockerfiles in Maven</description>
 
   <properties>
-    <docker-client.version>8.8.1</docker-client.version>
+    <docker-client.version>8.11.0</docker-client.version>
   </properties>
 
   <dependencyManagement>
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>20.0</version>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -15,7 +15,7 @@
   <description>Adds support for building Dockerfiles in Maven</description>
 
   <properties>
-    <docker-client.version>8.11.0</docker-client.version>
+    <docker-client.version>8.11.1</docker-client.version>
   </properties>
 
   <dependencyManagement>

--- a/plugin/src/it/basic-with-build-args/Dockerfile
+++ b/plugin/src/it/basic-with-build-args/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM hello-world
 MAINTAINER David Flemström <dflemstr@spotify.com>
 
 ARG IMAGE_VERSION


### PR DESCRIPTION
Incorporating recent security upgrades from docker-client:
* Bouncy Castle Cryptography APIs 1.52 (Mar 2015) -> 1.59 (Jan 2018)
* FasterXML Jackson 2.8.8 (Apr 2017) -> 2.9.4 (Jan 2018)

Upgrade of Guava is required by the Maven Enforcer (rule Require Upper Bound Dependencies).
