### PR TITLE
Add new "rmi" mojo to remove images

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,31 @@ parent POM) in order for the `docker-info` type to be supported:
 </build>
 ```
 
+### Clean images from Docker host after the build
+
+You can use the `rmi` goal (from `docker rmi`, a.k.a. `docker image
+remove`) to clean up the project's image on the Docker host, so that
+the storage on the host doesn't fill up. This is especially useful if
+you deploy tagged images to a Docker registry from a build host where
+you don't need the image anymore after the build. As with `docker
+rmi`, the `dockerfile.rmi.force` option must be set to `true` when
+removing tagged images.
+
+Set up the configuration like this to have Docker images cleaned when
+executing `mvn clean`:
+
+```xml
+<execution>
+  <id>clean</id>
+  <goals>
+    <goal>rmi</goal>
+  </goals>
+  <configuration>
+    <forceRemove>true</forceRemove>
+  </configuration>
+</execution>
+```
+
 ## Use other Docker tools that rely on Dockerfiles
 
 Your project(s) look like so:
@@ -287,6 +312,7 @@ You can pass options to maven to disable the docker goals.
 | dockerfile.build.skip | Disables the build goal; it becomes a no-op. |
 | dockerfile.tag.skip | Disables the tag goal; it becomes a no-op. |
 | dockerfile.push.skip | Disables the push goal; it becomes a no-op. |
+| dockerfile.rmi.skip | Disables the rmi goal; it becomes a no-op. |
 
 For example to skip the entire dockerfile plugin:
 ```

--- a/plugin/src/it/clean-empty-project/Dockerfile
+++ b/plugin/src/it/clean-empty-project/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+MAINTAINER David Flemström <dflemstr@spotify.com>

--- a/plugin/src/it/clean-empty-project/invoker.properties
+++ b/plugin/src/it/clean-empty-project/invoker.properties
@@ -1,0 +1,21 @@
+###
+# -/-/-
+# Dockerfile Maven Plugin
+# %%
+# Copyright (C) 2015 - 2016 Spotify AB
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -\-\-
+###
+
+invoker.goals=clean

--- a/plugin/src/it/clean-empty-project/pom.xml
+++ b/plugin/src/it/clean-empty-project/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -/-/-
+  Dockerfile Maven Plugin
+  %%
+  Copyright (C) 2015 - 2016 Spotify AB
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -\-\-
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spotify.it</groupId>
+  <artifactId>clean-empty-project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple IT verifying that the project can be cleaned before building anything.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>clean</id>
+            <goals>
+              <goal>rmi</goal>
+            </goals>
+            <configuration>
+              <forceRemove>true</forceRemove>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin/src/it/remove-tagged-image/Dockerfile
+++ b/plugin/src/it/remove-tagged-image/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+MAINTAINER David Flemström <dflemstr@spotify.com>

--- a/plugin/src/it/remove-tagged-image/invoker.properties
+++ b/plugin/src/it/remove-tagged-image/invoker.properties
@@ -1,0 +1,22 @@
+###
+# -/-/-
+# Dockerfile Maven Plugin
+# %%
+# Copyright (C) 2015 - 2016 Spotify AB
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -\-\-
+###
+
+invoker.goals=package
+invoker.goals.2=clean

--- a/plugin/src/it/remove-tagged-image/pom.xml
+++ b/plugin/src/it/remove-tagged-image/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -/-/-
+  Dockerfile Maven Plugin
+  %%
+  Copyright (C) 2015 - 2016 Spotify AB
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -\-\-
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spotify.it</groupId>
+  <artifactId>remove-tagged-image</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple IT verifying that tagged image IDs will can be removed.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <repository>test/remove-tagged-image</repository>
+            </configuration>
+          </execution>
+          <execution>
+            <id>clean</id>
+            <goals>
+              <goal>rmi</goal>
+            </goals>
+            <configuration>
+              <forceRemove>true</forceRemove>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/RemoveImageMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/RemoveImageMojo.java
@@ -1,0 +1,89 @@
+/*-
+ * -\-\-
+ * Dockerfile Maven Plugin
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.plugin.dockerfile;
+
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+@Mojo(name = "rmi",
+    defaultPhase = LifecyclePhase.PRE_CLEAN,
+    requiresProject = true,
+    threadSafe = true)
+public class RemoveImageMojo extends AbstractDockerMojo {
+
+  /**
+   * Whether to force removal of the image.
+   */
+  @Parameter(property = "dockerfile.rmi.force", defaultValue = "false")
+  private boolean forceRemove;
+
+  /**
+   * Whether to delete untagged parents.
+   */
+  @Parameter(property = "dockerfile.rmi.prune", defaultValue = "true")
+  private boolean prune;
+
+  /**
+   * Disables the tag goal; it becomes a no-op.
+   */
+  @Parameter(property = "dockerfile.rmi.skip", defaultValue = "false")
+  private boolean skipTag;
+
+  @Override
+  protected void execute(DockerClient dockerClient)
+      throws MojoExecutionException, MojoFailureException {
+    final Log log = getLog();
+
+    if (skipTag) {
+      log.info("Skipping execution because 'dockerfile.rmi.skip' is set");
+      return;
+    }
+
+    final String imageId = readMetadata(Metadata.IMAGE_ID);
+    if (imageId == null) {
+      log.info("No Docker image was built: Nothing to remove.");
+      return;
+    }
+
+    final StringBuilder messageBuilder = new StringBuilder();
+    messageBuilder.append("Removing image ");
+    messageBuilder.append(imageId);
+    if (forceRemove) {
+      messageBuilder.append(" with all tags");
+    }
+    if (prune) {
+      messageBuilder.append(", deleting untagged parents");
+    }
+    log.info(messageBuilder.toString());
+
+    try {
+      dockerClient.removeImage(imageId, forceRemove, !prune);
+    } catch (DockerException | InterruptedException e) {
+      throw new MojoExecutionException("Could not remove Docker image", e);
+    }
+  }
+}


### PR DESCRIPTION
I'm happily using this great plugin in a CI environment, however I have to regularly clean the build host from stale images. This pull request adds a `rmi` goal that behaves like `docker rmi` and binds to the pre-clean phase by default.

Additionally, two integration tests make sure the goal can be called, however, no automatic verification if the image was removed is performed. Let me know if I should try to add such a test, which would probably involve calling `docker-client` classes from `verify.groovy`.