### PR TITLE
#94 properly read maven proxy settings

### DIFF
--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/AbstractDockerMojo.java
@@ -108,6 +108,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
   protected boolean useMavenSettingsForAuth;
 
   /**
+   * Whether to connect to Docker Daemon using HTTP proxy, if set.
+   */
+  @Parameter(defaultValue = "false", property = "dockerfile.useProxy")
+  protected boolean useProxy;
+
+  /**
    * Directory where test metadata will be written during build.
    */
   @Parameter(defaultValue = "${project.build.testOutputDirectory}",
@@ -417,6 +423,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
           .readTimeoutMillis(readTimeoutMillis)
           .connectTimeoutMillis(connectTimeoutMillis)
           .registryAuthSupplier(authSupplier)
+          .useProxy(useProxy)
           .build();
     } catch (DockerCertificateException e) {
       throw new MojoExecutionException("Could not load Docker certificates", e);


### PR DESCRIPTION
When executing within the maven lifecycle, some of the proxy configuration from settings.xml is read (to set http.proxyHost, http.proxyPort, http.proxyUser and http.proxyPassword System properties), but for some reason http.nonProxyHosts is not properly set. Since version 8.9.1 of "docker-client", the http.proxyHost by default is used if set, hence dockerfile-maven is affected by this behaviour.

This is a known problem, fixed locally in other plugins (see e.g. https://issues.apache.org/jira/browse/CXF-4710).

This fix is inspired by the CFX fix above, to read the settings.xml and populate all relevant system properties for http proxy usage (and restore previous values after execution).