### PR TITLE
Support encrypted Maven server passwords in settings.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,17 @@ before running the plugin.
 
 [ADC]: https://developers.google.com/identity/protocols/application-default-credentials
 
+GCR users may need to initialize their Application Default Credentials via `gcloud`.
+Depending on where the plugin will run, they may wish to use [their Google
+identity][app-def-login] by running the following command
+
+    gcloud auth application-default login
+
+or [create a service account][service-acct] instead.
+
+[app-def-login]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
+[service-acct]: https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account
+
 ## Authenticating with maven settings.xml
 
 Since version 1.3.6, you can authenticate using your maven settings.xml instead
@@ -276,6 +287,15 @@ with this command line call
 
     mvn goal -Ddockerfile.username=... -Ddockerfile.password=...
     
+## Maven Goals
+
+Goals available for this plugin:
+
+| Goal      | Description    | Default Phase |
+| ---- | ---- | ---- |
+| `dockerfile:build` | Builds a Docker image from a Dockerfile. | `package` |
+| `dockerfile:tag` | Tags a Docker image. | `package` |
+| `dockerfile:push` | Pushes a Docker image to a repository. | `deploy` |
 
 ## Skip Docker Goals Bound to Maven Phases
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ Then, in your maven settings file, add configuration for the server:
 
 exactly as you would for any other server configuration.
 
+Since version 1.4.3, using an encrypted password in the Maven settings file is supported.  For more
+information about encrypting server passwords in `settings.xml`, 
+[read the documentation here](https://maven.apache.org/guides/mini/guide-encryption.html).
+
 ## Authenticating with maven pom.xml
 
 Since version 1.3.XX, you can authenticate using config from the pom itself.

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -69,6 +69,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.sonatype.plexus</groupId>
+      <artifactId>plexus-sec-dispatcher</artifactId>
+      <version>1.4</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.0</version>

--- a/plugin/src/it/maven-settings-auth/Dockerfile
+++ b/plugin/src/it/maven-settings-auth/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+MAINTAINER David Flemström <dflemstr@spotify.com>

--- a/plugin/src/it/maven-settings-auth/auth.properties
+++ b/plugin/src/it/maven-settings-auth/auth.properties
@@ -1,0 +1,2 @@
+# This system property overrides the path used for the settings-security.xml file.
+settings.security=settings-security.xml

--- a/plugin/src/it/maven-settings-auth/invoker.properties
+++ b/plugin/src/it/maven-settings-auth/invoker.properties
@@ -1,0 +1,33 @@
+###
+# -/-/-
+# Dockerfile Maven Plugin
+# %%
+# Copyright (C) 2015 - 2018 Spotify AB
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -\-\-
+###
+
+# The build will fail as we're pushing to a nonexistent Docker registry.
+invoker.buildResult=failure
+
+# Enable debug logging so that we can assert that the Maven server password was successfully
+# decrypted.
+invoker.debug=true
+
+# The deploy phase runs the dockerfile:push goal.
+invoker.goals=deploy
+
+# Overrides the path to settings-security.xml, which contains an encrypted master password.
+# See https://maven.apache.org/guides/mini/guide-encryption.html for more details.
+invoker.systemPropertiesFile=auth.properties

--- a/plugin/src/it/maven-settings-auth/pom.xml
+++ b/plugin/src/it/maven-settings-auth/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -/-/-
+  Dockerfile Maven Plugin
+  %%
+  Copyright (C) 2015 - 2018 Spotify AB
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -\-\-
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spotify.it</groupId>
+  <artifactId>maven-settings-auth</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Tests Docker registry authentication using an encrypted password in the Maven
+    settings.xml file.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+              <goal>push</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <repository>example.com/test/build</repository>
+          <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
+          <googleContainerRegistryEnabled>false</googleContainerRegistryEnabled>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin/src/it/maven-settings-auth/settings-security.xml
+++ b/plugin/src/it/maven-settings-auth/settings-security.xml
@@ -1,0 +1,9 @@
+<!--
+  Contains the encrypted master password used to encrypt/decrypt server passwords in the
+  Maven settings.xml file.
+
+  See https://maven.apache.org/guides/mini/guide-encryption.html for more details.
+-->
+<settingsSecurity>
+  <master>{fPB6uDF2BxcH5tT+mSXLWpd1tNw+TABncl/cf+uQQbw=}</master>
+</settingsSecurity>

--- a/plugin/src/it/maven-settings-auth/verify.groovy
+++ b/plugin/src/it/maven-settings-auth/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * -/-/-
+ * Dockerfile Maven Plugin
+ * %%
+ * Copyright (C) 2015 - 2018 Spotify AB
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -\-\-
+ */
+
+// Asserts that Maven server password decryption was successful.
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+assert buildLog.contains("[DEBUG] Successfully decrypted Maven server password")

--- a/plugin/src/it/settings.xml
+++ b/plugin/src/it/settings.xml
@@ -53,4 +53,13 @@
       </pluginRepositories>
     </profile>
   </profiles>
+
+  <servers>
+    <!-- Nonexistent Docker registry server used for testing authentication. -->
+    <server>
+      <username>testuser</username>
+      <password>{oZT21IwPcEkHpuwQX3oZdg/NZHHOL69SDb5vJXxxixU=}</password>
+      <id>example.com</id>
+    </server>
+  </servers>
 </settings>

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/MavenRegistryAuthSupplier.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/MavenRegistryAuthSupplier.java
@@ -20,17 +20,28 @@
 
 package com.spotify.plugin.dockerfile;
 
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher.SYSTEM_PROPERTY_SEC_LOCATION;
+
 import com.spotify.docker.client.ImageRef;
 import com.spotify.docker.client.auth.RegistryAuthSupplier;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.RegistryAuth;
 import com.spotify.docker.client.messages.RegistryConfigs;
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonatype.plexus.components.cipher.DefaultPlexusCipher;
+import org.sonatype.plexus.components.cipher.PlexusCipherException;
+import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
+import org.sonatype.plexus.components.sec.dispatcher.SecUtil;
+import org.sonatype.plexus.components.sec.dispatcher.model.SettingsSecurity;
 
 public class MavenRegistryAuthSupplier implements RegistryAuthSupplier {
 
@@ -47,9 +58,26 @@ public class MavenRegistryAuthSupplier implements RegistryAuthSupplier {
     final ImageRef ref = new ImageRef(imageName);
     Server server = settings.getServer(ref.getRegistryName());
     if (server != null) {
+      String password = server.getPassword();
+      boolean encrypted = false;
+      try {
+        encrypted = isEncrypted(password);
+      } catch (PlexusCipherException e) {
+        log.warn("Couldn't determine if Maven server password is encrypted.");
+        log.warn("Assuming Maven server password *is not* encrypted.", e);
+      }
+      try {
+        log.debug("Maven server password is encrypted: {}", encrypted);
+        if (encrypted) {
+          password = decryptPassword(password);
+          log.debug("Successfully decrypted Maven server password");
+        }
+      } catch (PlexusCipherException | SecDispatcherException e) {
+        throw new DockerException("Failed to decrypt Maven server password", e);
+      }
       return RegistryAuth.builder()
         .username(server.getUsername())
-        .password(server.getPassword())
+        .password(password)
         .build();
     }
     log.warn("Did not find maven server configuration for docker server " + ref.getRegistryName());
@@ -76,4 +104,58 @@ public class MavenRegistryAuthSupplier implements RegistryAuthSupplier {
     return RegistryConfigs.create(allConfigs);
   }
 
+  /**
+   * Decrypts the supplied Maven server password using the master password from {@link
+   * SettingsSecurity}.
+   *
+   * @param encryptedPassword the encrypted server password
+   * @return the decrypted server password
+   * @throws PlexusCipherException if decryption fails
+   * @throws SecDispatcherException if {@link SettingsSecurity} can't be read
+   */
+  private String decryptPassword(String encryptedPassword)
+      throws PlexusCipherException, SecDispatcherException {
+    // Use -Dsettings.security=... to override the location of the security settings XML file.
+    String location = System
+        .getProperty(SYSTEM_PROPERTY_SEC_LOCATION, "~/.m2/settings-security.xml");
+    checkState(!isNullOrEmpty(location), "Location of settings-security.xml must not be empty");
+    String realLocation = location.charAt(0) == '~'
+        ? System.getProperty("user.home") + location.substring(1)
+        : location;
+    log.debug("Using location of '{}' for settings-security.xml",
+        new File(realLocation).getAbsolutePath());
+    SettingsSecurity settingsSecurity = SecUtil.read(realLocation, true);
+    String encryptedMasterPassword = settingsSecurity.getMaster();
+    String decryptedMasterPassword = decryptPassword(encryptedMasterPassword,
+        DefaultSecDispatcher.SYSTEM_PROPERTY_SEC_LOCATION);
+    return decryptPassword(encryptedPassword, decryptedMasterPassword);
+  }
+
+  /**
+   * Decrypts a Maven server password.
+   *
+   * @param encryptedPassword the encrypted server password
+   * @param passPhrase the password used to encrypt the server password
+   * @return the decrypted password
+   * @throws PlexusCipherException if decryption fails
+   */
+  private static String decryptPassword(String encryptedPassword, String passPhrase)
+      throws PlexusCipherException {
+    DefaultPlexusCipher cipher = new DefaultPlexusCipher();
+    return cipher.decryptDecorated(encryptedPassword, passPhrase);
+  }
+
+  /**
+   * Determines if the supplied Maven server password is encrypted or not.
+   *
+   * @param password the password to test
+   * @return true if the password is encrypted, otherwise false
+   * @see <a href=https://maven.apache.org/guides/mini/guide-encryption.html">Password
+   *     Encryption</a>
+   * @throws PlexusCipherException if the decryption algorithm isn't available
+   */
+  private static boolean isEncrypted(String password) throws PlexusCipherException {
+    DefaultPlexusCipher cipher = new DefaultPlexusCipher();
+    return cipher.isEncryptedString(password);
+  }
 }


### PR DESCRIPTION
Thanks for this plugin!

We normally use encrypted passwords in `settings.xml` according to Maven's [password encryption instructions](https://maven.apache.org/guides/mini/guide-encryption.html).

This change allows Docker registry passwords to be stored in encrypted form in `settings.xml`, and accessed and decrypted via the usual `useMavenSettingsForAuth=true` property in the `dockerfile-maven` plugin.

Related issues:

https://github.com/spotify/dockerfile-maven/issues/78
https://github.com/spotify/dockerfile-maven/issues/84
https://github.com/spotify/dockerfile-maven/issues/122