### PR TITLE
Update ISSUE_TEMPLATE.md to point questions to SO and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!-- This form is for bug reports and feature requests ONLY!
+
+If you're looking for help check
+[Stack Overflow](https://stackoverflow.com/questions/tagged/spotify-dockerfile-maven) and the docs.
+-->
+
+**Is this a BUG REPORT or FEATURE REQUEST?**:
+
+## Description
+
+[Add feature/bug description here]
+
+## How to reproduce
+
+[Add steps on how to reproduce this issue]
+
+## What do you expect
+
+[Describe what do you expect to happen]
+
+## What happened instead
+
+[Describe the actual results]
+
+## Software:
+
+- `docker version`: [Add the output of `docker version` here, both client and server]
+- Spotify's dockerfile-maven version: [Add dockerfile-maven version here]
+
+## Full backtrace
+
+```text
+[Paste full backtrace here]
+```
+


### PR DESCRIPTION
We get a lot of issues that are just questions on usage. Let's direct these
to StackOverflow and the docs so issues can be reserved for bugs and
feature requests.