### PR TITLE
update docker-client version

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -15,7 +15,7 @@
   <description>Adds support for building Dockerfiles in Maven</description>
 
   <properties>
-    <docker-client.version>8.11.4</docker-client.version>
+    <docker-client.version>8.11.7</docker-client.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Update docker-client version to updated client with fix for newer ecdsa key files.
The latest docker uses ecdsa instead of rsa keys.