### PR TITLE
Update the docker-client to 8.11.7.

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -15,7 +15,7 @@
   <description>Adds support for building Dockerfiles in Maven</description>
 
   <properties>
-    <docker-client.version>8.11.4</docker-client.version>
+    <docker-client.version>8.11.7</docker-client.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
In particular, it contains a fix for the issue described in spotify/docker-client/pull/1036 (broken credential support on macOS).