### PR TITLE
Promoting to the latest version of guava due to CVE-2018-10237

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>25.0-jre</version>
+      <version>25.0-android</version>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>20.0</version>
+      <version>25.0-jre</version>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>
@@ -117,7 +117,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.5.2</version>
         <configuration>
           <goalPrefix>dockerfile</goalPrefix>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>


### PR DESCRIPTION
I would like to ask you to promote version of guava to at least version 25.0-jre in order to eliminate the eager allocation of the arrays. 

More details you may find here: https://github.com/google/guava/wiki/CVE-2018-10237#cve-2018-10237