### PR TITLE
Add probot/stale config to close stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,12 @@
+daysUntilStale: 60
+daysUntilClose: 7
+exemptLabels:
+  - pinned
+  - security
+staleLabel: stale
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: false
+only: issues


### PR DESCRIPTION
It has been working pretty well for spotify/docker-maven-plugin
since we added it here https://github.com/spotify/docker-maven-plugin/pull/400.