### PR TITLE
travis: test on jdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 
 jdk:
+  - oraclejdk9
   - openjdk8
   - openjdk7
 


### PR DESCRIPTION
Travis doesn't seem to have `openjdk9`, so using `oraclejdk9`.