### PR TITLE
Fix NPE during dockerfile build

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -67,6 +67,18 @@
       <artifactId>maven-archiver</artifactId>
       <version>3.0.0</version>
     </dependency>
+    
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-archiver</artifactId>
+      <version>3.1.1</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.18</version>
+    </dependency>
 
     <dependency>
       <groupId>org.sonatype.plexus</groupId>


### PR DESCRIPTION
This PR addresses the NPE issue during dockerfile-maven plugin steps, specifically, this issue:
https://github.com/spotify/dockerfile-maven/issues/163

It upgrades:
  1. `plexus-archiver` from 2.9.1 -> 3.1.1
  2. `commons-compress` from 1.9 -> 1.18 (this is required to due a conflicting version in `docker-client`)

Relevant commits:
https://github.com/codehaus-plexus/plexus-archiver/issues/28
https://github.com/apache/maven-archiver/commit/0b1cf25e61bae420c3c6788634b0b26c0eef98c0#diff-600376dffeb79835ede4a0b285078036

Note - this is the specific stack trace that I receive (and am addressing in this PR) on `OpenJDK11` and `maven 3.5.4`. 

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
    at org.codehaus.plexus.archiver.zip.AbstractZipArchiver.<clinit> (AbstractZipArchiver.java:116)
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0 (Native Method)
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance (NativeConstructorAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance (DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance (Constructor.java:490)
```

