### PR TITLE
update org.apache.maven:maven-archiver to resolve Java 11 issue 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 
 jdk:
+  - openjdk11
   - openjdk10
   - openjdk9
   - openjdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## 1.4.6 (release TBD)
+- Fix an ExceptionInInitializerError when plugin is used on Java 11 ([230][])
+
+[230]: https://github.com/spotify/dockerfile-maven/pull/230
+
+## 1.4.6 (released October 5 2018)
 
 - Support for Java 9 and 10
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,6 +25,16 @@
         <artifactId>jsr305</artifactId>
         <version>2.0.1</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.14</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-interpolation</artifactId>
+        <version>1.24</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -43,7 +53,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>20.0</version>
+      <version>23.6.1-jre</version>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>
@@ -54,18 +64,18 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.3.9</version>
+      <version>3.5.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.3.9</version>
+      <version>3.5.4</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
-      <version>3.0.0</version>
+      <version>3.2.0</version>
     </dependency>
 
     <dependency>
@@ -83,7 +93,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.4</version>
+      <version>3.5.2</version>
       <scope>provided</scope>
     </dependency>
 
@@ -117,7 +127,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.5.2</version>
         <configuration>
           <goalPrefix>dockerfile</goalPrefix>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>


### PR DESCRIPTION
update org.apache.maven:maven-archiver to resolve Java 11 issue

see https://github.com/spotify/dockerfile-maven/issues/77#issuecomment-331531574 - for some reason org.codehaus.plexus.archiver.zip.AbstractZipArchiver (which comes from a transitive dependency of maven-archiver) is throwing an exception on Java 11 when maven-archiver is at v3.0.0. Updated to latest (3.2.0) to pull in newer transitive dependencies.

Also upgraded a bunch of other dependencies that caused
requireUpperBoundsDep problems once maven-archiver was at 3.2.0

