### PR TITLE
update compiler source/target from 1.7 to 1.8

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -110,8 +110,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Java 8 is nearing EOL, so we can probably safely stop outputting 1.7
compatible classes