### PR TITLE
Upgrade org.apache.commons:comons-compress to fix vuln

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.14</version>
+        <version>1.18</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
See CVE-2018-11771 https://nvd.nist.gov/vuln/detail/CVE-2018-11771.