### PR TITLE
make it/multi-module/{a,b} actually depend on each other, serving as …

### DIFF
--- a/plugin/src/it/multi-module/b/Dockerfile
+++ b/plugin/src/it/multi-module/b/Dockerfile
@@ -1,2 +1,3 @@
-FROM scratch
+FROM test/multi-module-a:unstable
 MAINTAINER David Flemström <dflemstr@spotify.com>
+ENV foo=bar

--- a/plugin/src/it/multi-module/b/pom.xml
+++ b/plugin/src/it/multi-module/b/pom.xml
@@ -62,6 +62,24 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <repository>test/multi-module-b</repository>
+              <tag>unstable</tag>
+              <pullNewerImage>false</pullNewerImage>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
I suggest turning the integration test dockerfile-maven/plugin/src/it/multi-module into an actual example of two docker images where the second one is built from the contents of the other. Currently both are built from scratch, but I suggest that multi-module/b is built from multi-module/a. Recently, I had to do something like that myself and it took me a while to figure out that you need to set dockerfile.build.pullNewerImage to true in my equivalent of multi-module/b , because otherwise it tries to pull the image a instead of using the just built local one. (Compare https://github.com/spotify/dockerfile-maven/issues/261 ).

My PR changes that multi-module/b is built from multi-module/a and sets pullNewerImage to true. I did not verify that the included docker-info of multi-module/a is actually used for something in multi-module/b - I don't know where to look and I didn't need that feature. The test in dockerfile-maven/plugin/src/it/multi-module/verify.groovy doesn't seem to verify that, anyway - that's probably room to improve.

Thanks for your very valuable tool!