### PR TITLE
Validation of docker repository names

### DIFF
--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -34,6 +34,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -221,6 +222,7 @@ public class BuildMojo extends AbstractDockerMojo {
     log.info(""); // Spacing around build progress
     try {
       if (repository != null) {
+        validateRepository(repository);
         final String name = formatImageName(repository, tag);
         log.info(MessageFormat.format("Image will be built as {0}", name));
         log.info(""); // Spacing around build progress
@@ -236,6 +238,20 @@ public class BuildMojo extends AbstractDockerMojo {
     log.info(""); // Spacing around build progress
 
     return progressHandler.builtImageId();
+  }
+
+  private static String VALID_REPO_REGEX =
+          "^([a-z0-9_.-])+(\\/(?=[a-z0-9_.-])[a-z0-9_.-]+)*$";
+
+
+  static void validateRepository(@Nonnull String repository)
+      throws MojoFailureException {
+    Pattern pattern = Pattern.compile(VALID_REPO_REGEX);
+    if (!pattern.matcher(repository).matches()) {
+      throw new MojoFailureException(
+              "Repo name \"" + repository +
+                      "\" must contain only lowercase, numbers, '-', '_' or '.'.");
+    }
   }
 
   private static void requireValidDockerFilePath(@Nonnull Log log,

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -50,6 +50,10 @@ import org.apache.maven.plugins.annotations.Parameter;
     requiresProject = true,
     threadSafe = true)
 public class BuildMojo extends AbstractDockerMojo {
+  /**
+   * Regex for a valid docker repository name.  Used in validateRepository().
+   */
+  private static final String VALID_REPO_REGEX = "^([a-z0-9_.-])+(\\/[a-z0-9_.-]+)*$";
 
   /**
    * Directory containing the the build context. This is typically the directory that contains
@@ -229,7 +233,7 @@ public class BuildMojo extends AbstractDockerMojo {
                           + repository
                           + "\" must contain only lowercase, numbers, '-', '_' or '.'.");
         }
-          ;
+
         final String name = formatImageName(repository, tag);
         log.info(MessageFormat.format("Image will be built as {0}", name));
         log.info(""); // Spacing around build progress
@@ -246,8 +250,6 @@ public class BuildMojo extends AbstractDockerMojo {
 
     return progressHandler.builtImageId();
   }
-
-  private static final String VALID_REPO_REGEX = "^([a-z0-9_.-])+(\\/[a-z0-9_.-]+)*$";
 
   @VisibleForTesting
   static boolean validateRepository(@Nonnull String repository) {

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -241,7 +241,7 @@ public class BuildMojo extends AbstractDockerMojo {
   }
 
   private static String VALID_REPO_REGEX =
-          "^([a-z0-9_.-])+(\\/(?=[a-z0-9_.-])[a-z0-9_.-]+)*$";
+          "^([a-z0-9_.-])+(\\/[a-z0-9_.-]+)*$";
 
 
   static void validateRepository(@Nonnull String repository)
@@ -249,8 +249,9 @@ public class BuildMojo extends AbstractDockerMojo {
     Pattern pattern = Pattern.compile(VALID_REPO_REGEX);
     if (!pattern.matcher(repository).matches()) {
       throw new MojoFailureException(
-              "Repo name \"" + repository +
-                      "\" must contain only lowercase, numbers, '-', '_' or '.'.");
+              "Repo name \""
+                      + repository
+                      + "\" must contain only lowercase, numbers, '-', '_' or '.'.");
     }
   }
 

--- a/plugin/src/test/java/com/spotify/plugin/dockerfile/TestRepoNameValidation.java
+++ b/plugin/src/test/java/com/spotify/plugin/dockerfile/TestRepoNameValidation.java
@@ -1,0 +1,72 @@
+/*-
+ * -\-\-
+ * Dockerfile Maven Plugin
+ * --
+ * Copyright (C) 2019 Simon Woodward
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.plugin.dockerfile;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TestRepoNameValidation {
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testSuccess() throws MojoFailureException {
+    BuildMojo.validateRepository("alllowercase");
+    BuildMojo.validateRepository("with000numbers");
+    BuildMojo.validateRepository("00withnumbers");
+    BuildMojo.validateRepository("00757383");
+    BuildMojo.validateRepository("withnumbers34343");
+    BuildMojo.validateRepository("with-hyphens");
+    BuildMojo.validateRepository("with_underscores");
+    BuildMojo.validateRepository("with.dots");
+    BuildMojo.validateRepository("______");
+    BuildMojo.validateRepository("------");
+    BuildMojo.validateRepository("......");
+    BuildMojo.validateRepository("example.com/okay./.path");
+    BuildMojo.validateRepository(".start.and.end.");
+    BuildMojo.validateRepository("-start-and-end-");
+    BuildMojo.validateRepository("_start_and_end_");
+    // Forward slash delimits the repo user from the repo name; strictly speaking,
+    // you're allowed only one slash, somewhere in the middle.
+    BuildMojo.validateRepository("with/forwardslash");
+    BuildMojo.validateRepository("with/multiple/forwardslash");
+  }
+
+  private boolean throwsMojoFailure(String repoName) {
+    boolean threw = false;
+    try {
+      BuildMojo.validateRepository(repoName);
+    } catch (MojoFailureException e) {
+      threw = true;
+    }
+    return threw;
+  }
+
+  @Test
+  public void testFailCases() {
+    assertTrue("Mixed case didn't fail", throwsMojoFailure("ddddddDddddd"));
+    assertTrue("Symbols didn't fail", throwsMojoFailure("ddddddDd+dddd"));
+    assertTrue("Starting slash didn't fail", throwsMojoFailure("/atstart"));
+    assertTrue("Ending slash didn't fail", throwsMojoFailure("atend/"));
+  }
+}

--- a/plugin/src/test/java/com/spotify/plugin/dockerfile/TestRepoNameValidation.java
+++ b/plugin/src/test/java/com/spotify/plugin/dockerfile/TestRepoNameValidation.java
@@ -20,6 +20,7 @@
 
 package com.spotify.plugin.dockerfile;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.maven.plugin.MojoFailureException;
@@ -31,42 +32,32 @@ public class TestRepoNameValidation {
 
   @Test
   public void testSuccess() throws MojoFailureException {
-    BuildMojo.validateRepository("alllowercase");
-    BuildMojo.validateRepository("with000numbers");
-    BuildMojo.validateRepository("00withnumbers");
-    BuildMojo.validateRepository("00757383");
-    BuildMojo.validateRepository("withnumbers34343");
-    BuildMojo.validateRepository("with-hyphens");
-    BuildMojo.validateRepository("with_underscores");
-    BuildMojo.validateRepository("with.dots");
-    BuildMojo.validateRepository("______");
-    BuildMojo.validateRepository("------");
-    BuildMojo.validateRepository("......");
-    BuildMojo.validateRepository("example.com/okay./.path");
-    BuildMojo.validateRepository(".start.and.end.");
-    BuildMojo.validateRepository("-start-and-end-");
-    BuildMojo.validateRepository("_start_and_end_");
+    assertTrue("All lower case should work", BuildMojo.validateRepository("alllowercase"));
+    assertTrue("With numbers", BuildMojo.validateRepository("with000numbers"));
+    assertTrue("Begin with numbers", BuildMojo.validateRepository("00withnumbers"));
+    assertTrue("All numbers", BuildMojo.validateRepository("00757383"));
+    assertTrue("End with numbers", BuildMojo.validateRepository("withnumbers34343"));
+    assertTrue("With hyphens", BuildMojo.validateRepository("with-hyphens"));
+    assertTrue("with underscores", BuildMojo.validateRepository("with_underscores"));
+    assertTrue("With dots", BuildMojo.validateRepository("with.dots"));
+    assertTrue("All underscores", BuildMojo.validateRepository("______"));
+    assertTrue("All hyphens", BuildMojo.validateRepository("------"));
+    assertTrue("All dots", BuildMojo.validateRepository("......"));
+    assertTrue("Multipart", BuildMojo.validateRepository("example.com/okay./.path"));
+    assertTrue("Start and end with dots", BuildMojo.validateRepository(".start.and.end."));
+    assertTrue("Start and end with hyphens", BuildMojo.validateRepository("-start-and-end-"));
+    assertTrue("Start and end with underscores", BuildMojo.validateRepository("_start_and_end_"));
     // Forward slash delimits the repo user from the repo name; strictly speaking,
     // you're allowed only one slash, somewhere in the middle.
-    BuildMojo.validateRepository("with/forwardslash");
-    BuildMojo.validateRepository("with/multiple/forwardslash");
-  }
-
-  private boolean throwsMojoFailure(String repoName) {
-    boolean threw = false;
-    try {
-      BuildMojo.validateRepository(repoName);
-    } catch (MojoFailureException e) {
-      threw = true;
-    }
-    return threw;
+    assertTrue("Multipart", BuildMojo.validateRepository("with/forwardslash"));
+    assertTrue("Multi-multipart", BuildMojo.validateRepository("with/multiple/forwardslash"));
   }
 
   @Test
   public void testFailCases() {
-    assertTrue("Mixed case didn't fail", throwsMojoFailure("ddddddDddddd"));
-    assertTrue("Symbols didn't fail", throwsMojoFailure("ddddddDd+dddd"));
-    assertTrue("Starting slash didn't fail", throwsMojoFailure("/atstart"));
-    assertTrue("Ending slash didn't fail", throwsMojoFailure("atend/"));
+    assertFalse("Mixed case didn't fail", BuildMojo.validateRepository("ddddddDddddd"));
+    assertFalse("Symbols didn't fail", BuildMojo.validateRepository("ddddddDd+dddd"));
+    assertFalse("Starting slash didn't fail", BuildMojo.validateRepository("/atstart"));
+    assertFalse("Ending slash didn't fail", BuildMojo.validateRepository("atend/"));
   }
 }


### PR DESCRIPTION
This change adds an early validation of repo names specified in the pom.  

An invalid name will now cause an early build failure with a clear message in the build log, rather than the incomprehensible “broken pipe” error at docker build time.