### PR TITLE
Update docker-client version to 8.14.5

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -15,7 +15,7 @@
   <description>Adds support for building Dockerfiles in Maven</description>
 
   <properties>
-    <docker-client.version>8.14.3</docker-client.version>
+    <docker-client.version>8.14.5</docker-client.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Fixes #278 

This update fixes issue described here https://github.com/spotify/docker-client/issues/875 about supporting Windows named pipes.