### PR TITLE
allow define port in repository

### DIFF
--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -53,7 +53,7 @@ public class BuildMojo extends AbstractDockerMojo {
   /**
    * Regex for a valid docker repository name.  Used in validateRepository().
    */
-  private static final String VALID_REPO_REGEX = "^([a-z0-9_.-])+(\\/[a-z0-9_.-]+)*$";
+  private static final String VALID_REPO_REGEX = "^([a-z0-9_.:-])+(/[a-z0-9_.-]+)*$";
 
   /**
    * Directory containing the the build context. This is typically the directory that contains


### PR DESCRIPTION
Added colon to validation regex so user can also define port for registry - e.g. `my.private.docker.registry:1234/my/custom/image:1.0.0`