### PR TITLE
Updated docker-client version 8.15.3

### DIFF
--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dockerfile-maven</artifactId>
     <groupId>com.spotify</groupId>
-    <version>1.4.11-SNAPSHOT</version>
+    <version>1.4.12-SNAPSHOT</version>
   </parent>
 
   <artifactId>dockerfile-maven-extension</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>dockerfile-maven</artifactId>
-    <version>1.4.11-SNAPSHOT</version>
+    <version>1.4.12-SNAPSHOT</version>
   </parent>
 
   <artifactId>dockerfile-maven-plugin</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -15,7 +15,7 @@
   <description>Adds support for building Dockerfiles in Maven</description>
 
   <properties>
-    <docker-client.version>8.14.5</docker-client.version>
+    <docker-client.version>8.15.3</docker-client.version>
   </properties>
 
   <dependencyManagement>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>dockerfile-maven-extension</artifactId>
-      <version>1.4.11-SNAPSHOT</version>
+      <version>1.4.12-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>dockerfile-maven</artifactId>
-  <version>1.4.11-SNAPSHOT</version>
+  <version>1.4.12-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Dockerfile Maven Support</name>


### PR DESCRIPTION
I'm integrating a build with Jenkins where it will generate temp credentials with DOCKER_CONFIG

This support was introduced in docker-client 8.15.3 https://github.com/spotify/docker-client/issues/1151

It would be great to have it updated

