### PR TITLE
Fix for #292: Skip plugin execution when a Dockerfile is not present

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,6 @@ You can pass options to maven to disable the docker goals.
 | Maven Option  | What Does it Do?           | Default Value |
 | ------------- | -------------------------- | ------------- |
 | `dockerfile.skip` | Disables the entire dockerfile plugin; all goals become no-ops. | false |
-| `dockerfile.failedOnMissingDockerfile` | Failed maven build when there is no default Dockerfile in the project/module. | true |
 | `dockerfile.build.skip` | Disables the build goal; it becomes a no-op. | false |
 | `dockerfile.tag.skip` | Disables the tag goal; it becomes a no-op. | false |
 | `dockerfile.push.skip` | Disables the push goal; it becomes a no-op. | false |
@@ -36,6 +35,7 @@ mvn clean package -Ddockerfile.skip
 | `dockerfile.contextDirectory` | Directory containing the Dockerfile to build. | yes | none |
 | `dockerfile.repository` | The repository to name the built image | no | none |
 | `dockerfile.tag` | The tag to apply when building the Dockerfile, which is appended to the repository. | no | latest |
+| `dockerfile.failedOnMissingDockerfile` | Failed maven build when there is no default Dockerfile in the project/module. | true |
 | `dockerfile.build.pullNewerImage` | Updates base images automatically. | no | true |
 | `dockerfile.build.noCache` | Do not use cache when building the image. | no | false |
 | `dockerfile.build.cacheFrom` | Docker image used as cache-from. Pulled in advance if not exist locally or `pullNewerImage` is `false` | no | none |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,6 +17,7 @@ You can pass options to maven to disable the docker goals.
 | Maven Option  | What Does it Do?           | Default Value |
 | ------------- | -------------------------- | ------------- |
 | `dockerfile.skip` | Disables the entire dockerfile plugin; all goals become no-ops. | false |
+| `dockerfile.failedOnMissingDockerfile` | Failed maven build when there is no default Dockerfile in the project/module. | true |
 | `dockerfile.build.skip` | Disables the build goal; it becomes a no-op. | false |
 | `dockerfile.tag.skip` | Disables the tag goal; it becomes a no-op. | false |
 | `dockerfile.push.skip` | Disables the push goal; it becomes a no-op. | false |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,7 @@ mvn clean package -Ddockerfile.skip
 | `dockerfile.contextDirectory` | Directory containing the Dockerfile to build. | yes | none |
 | `dockerfile.repository` | The repository to name the built image | no | none |
 | `dockerfile.tag` | The tag to apply when building the Dockerfile, which is appended to the repository. | no | latest |
-| `dockerfile.failedOnMissingDockerfile` | Failed maven build when there is no default Dockerfile in the project/module. | true |
+| `dockerfile.failedOnMissingDockerfile` | Failed maven build when there is no default Dockerfile in the project/module. | no | true
 | `dockerfile.build.pullNewerImage` | Updates base images automatically. | no | true |
 | `dockerfile.build.noCache` | Do not use cache when building the image. | no | false |
 | `dockerfile.build.cacheFrom` | Docker image used as cache-from. Pulled in advance if not exist locally or `pullNewerImage` is `false` | no | none |

--- a/plugin/src/it/multi-module/c/pom.xml
+++ b/plugin/src/it/multi-module/c/pom.xml
@@ -23,26 +23,40 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.spotify.it</groupId>
-  <artifactId>multi-module</artifactId>
-  <version>1.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
+  <parent>
+    <groupId>com.spotify.it</groupId>
+    <artifactId>multi-module</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
 
-  <description>This project has two modules that depend on each other.</description>
+  <artifactId>c</artifactId>
 
-  <modules>
-    <module>a</module>
-    <module>b</module>
-    <module>c</module>
-  </modules>
+  <description>The third module</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
   <build>
-    <extensions>
-      <extension>
+    <plugins>
+      <plugin>
         <groupId>@project.groupId@</groupId>
-        <artifactId>dockerfile-maven-extension</artifactId>
+        <artifactId>@project.artifactId@</artifactId>
         <version>@project.version@</version>
-      </extension>
-    </extensions>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <repository>test/multi-module-c</repository>
+              <tag>unstable</tag>
+              <failedOnMissingDockerfile>false</failedOnMissingDockerfile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/plugin/src/it/multi-module/verify.groovy
+++ b/plugin/src/it/multi-module/verify.groovy
@@ -28,3 +28,6 @@ assert tagFile.text == "unstable\n"
 
 File imageNameFile = new File(basedir, "b/target/docker-info-deps/META-INF/docker/com.spotify.it/a/image-name")
 assert imageNameFile.text == "test/multi-module-a:unstable\n"
+
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+assert buildLog.contains("docker-maven plugin execution is skipped for:")


### PR DESCRIPTION
A  new config key `dockerfile.failedOnMissingDockerfile` has been added for this fix.

More info on #292 