### PR TITLE
Update documentation to add parameter dockerfile

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,8 @@ mvn clean package -Ddockerfile.skip
 
 | Maven Option  | What Does it Do?           | Required | Default Value |
 | ------------- | -------------------------- | -------- | ------------- |
-| `dockerfile.contextDirectory` | Directory containing the Dockerfile to build. | yes | none |
+| `dockerfile.contextDirectory` | Directory containing the Dockerfile to build. | no | ${project.basedir} |
+| `dockerfile.dockerfile` | File name of the Dockerfile (if not `Dockerfile`) | no | none |
 | `dockerfile.repository` | The repository to name the built image | no | none |
 | `dockerfile.tag` | The tag to apply when building the Dockerfile, which is appended to the repository. | no | latest |
 | `dockerfile.build.pullNewerImage` | Updates base images automatically. | no | true |


### PR DESCRIPTION
This parameter is already available but not documented.

I use this parameter like this : 

```
          <configuration>
            <dockerfile>Dockerfile.tomcat</dockerfile>
            <repository>${docker.repository}</repository>
            <tag>${project.version}</tag>
          </configuration>
```

It work well to create multiple image from a single project ! (for example with multiple maven profiles)

Thanks a lot for the hard work on this plugin,