### PR TITLE
Fix cachefrom option to work correctly

### DIFF
--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -212,8 +212,8 @@ public class BuildMojo extends AbstractDockerMojo {
         }
       }
       if (!cacheFromExistLocally.isEmpty()) {
-        buildParameters.add(new DockerClient.BuildParam("cache-from",
-                encodeBuildParam(cacheFromExistLocally)));
+        buildParameters.add(new DockerClient.BuildParam("cachefrom",
+                new Gson().toJson(cacheFromExistLocally).toString()));
       }
     }
 


### PR DESCRIPTION
Currently, the cacheFrom build option, which pulls a Docker image to use it for the build cache doesn't seem to be working. It pulls the image and says it will use the image for the build cache, but it doesn't actually get used. This PR fixes it. 

https://docs.docker.com/engine/api/v1.40/#operation/ImageBuild
According to the Docker engine API docs it should be passed in as "cachefrom" and does not need to be encoded, just as a JSON list.

This fix is crucial when building on serverless hosts, since images end up being rebuilt without the build cache which takes extra time, and it also ends up taking extra space when pushing the image to a Docker registry.