### PR TITLE
update Changelog for 1.14.11 - 1.14.13, setup gren

### DIFF
--- a/.grenrc.yml
+++ b/.grenrc.yml
@@ -1,0 +1,8 @@
+---
+  dataSource: "prs"
+  prefix: ""
+  ignoreLabels: []
+  ignoreIssuesWith: []
+  onlyMilestones: false
+  groupBy: false
+  changelogFilename: "CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.4.13 (October 15 2019)
+- [**closed**] #308 Extend repository validation by allowing port number. [#309](https://github.com/spotify/dockerfile-maven/pull/309)
+- [**closed**] doc [#318](https://github.com/spotify/dockerfile-maven/pull/318)
+
+## v1.4.12 (July 29 2019)
+- [**closed**] Upgrade docker-client dep from 8.14.5 to 8.16.0 [#307](https://github.com/spotify/dockerfile-maven/pull/307)
+
+## v1.4.11 (July 29 2019)
+- [**closed**] Validation of docker repository names [#275](https://github.com/spotify/dockerfile-maven/pull/275)
+- [**closed**] Update docker-client version to 8.14.5 [#280](https://github.com/spotify/dockerfile-maven/pull/280)
+
 ## 1.4.10 (released January 15 2019)
 - Add support for --squash experimental build option ([248][])
 - Add support for specifying a custom Dockerfile location ([89][])
@@ -71,7 +82,7 @@
 [13]: https://github.com/spotify/dockerfile-maven/pull/13
 [17]: https://github.com/spotify/dockerfile-maven/pull/17
 
-## Earlier releases 
+## Earlier releases
 
 Please check the [list of commits on Github][commits].
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See the [changelog for a list of releases][changelog]
 
 ## Set-up
 
-This plugin requires Java 7 or later and Apache Maven 3 or later (dockerfile-maven-plugin <=1.4.6 needs 
+This plugin requires Java 7 or later and Apache Maven 3 or later (dockerfile-maven-plugin <=1.4.6 needs
 Maven >= 3, and for other cases, Maven >= 3.5.2). To run the integration tests or to use the plugin in practice, a working
 Docker set-up is needed.
 
@@ -216,6 +216,16 @@ See [authentication docs](https://github.com/spotify/dockerfile-maven/blob/maste
 
 ## Releasing
 
-`mvn clean [-B -Dinvoker.skip -DskipTests -Darguments='-Dinvoker.skip -DskipTests'] \
+To cut the Maven release:
+
+```
+mvn clean [-B -Dinvoker.skip -DskipTests -Darguments='-Dinvoker.skip -DskipTests'] \
   -Dgpg.keyname=<key ID used for signing artifacts> \
-  release:clean release:prepare release:perform`
+  release:clean release:prepare release:perform
+```
+
+We use [`gren`](https://github.com/github-tools/github-release-notes#installation) to create Releases in Github:
+
+```
+gren release
+```


### PR DESCRIPTION
[gren](https://github.com/github-tools/github-release-notes#installation)
can be used to automate creating Releases in Github and the changelog.

Since we already have a changelog file in the repo, I didn't replace it
(gren will sort the releases in the reverse order), but I did run `gren
release` for each past release to populate https://github.com/spotify/dockerfile-maven/releases