### PR TITLE
bump commons-compress to 1.19 for CVE-2019-12402

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.18</version>
+        <version>1.19</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
I noticed an automated Github security warning for
https://nvd.nist.gov/vuln/detail/CVE-2019-12402