### PR TITLE
Support for build args with space

### DIFF
--- a/plugin/src/it/basic-with-build-args/Dockerfile
+++ b/plugin/src/it/basic-with-build-args/Dockerfile
@@ -2,5 +2,9 @@ FROM hello-world
 MAINTAINER David Flemström <dflemstr@spotify.com>
 
 ARG IMAGE_VERSION
+ARG ARG_WITH_SPACE
+ARG ARG_WITH_PLUS
 
 LABEL version=${IMAGE_VERSION}
+LABEL arg_with_space=${ARG_WITH_SPACE}
+LABEL arg_with_plus=${ARG_WITH_PLUS}

--- a/plugin/src/it/basic-with-build-args/pom.xml
+++ b/plugin/src/it/basic-with-build-args/pom.xml
@@ -50,6 +50,8 @@
         <configuration>
           <buildArgs>
             <IMAGE_VERSION>0.0.1</IMAGE_VERSION>
+            <ARG_WITH_SPACE>arg with space</ARG_WITH_SPACE>
+            <ARG_WITH_PLUS>arg+with+plus</ARG_WITH_PLUS>
           </buildArgs>
         </configuration>
       </plugin>

--- a/plugin/src/it/basic-with-build-args/verify.groovy
+++ b/plugin/src/it/basic-with-build-args/verify.groovy
@@ -26,3 +26,5 @@ DefaultDockerClient dockerClient = DefaultDockerClient.fromEnv().build()
 imageInfo = dockerClient.inspectImage(imageId)
 
 assert imageInfo.config().labels().get("version") == "0.0.1"
+assert imageInfo.config().labels().get("arg_with_space") == "arg with space"
+assert imageInfo.config().labels().get("arg_with_plus") == "arg+with+plus"

--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
@@ -290,7 +291,9 @@ public class BuildMojo extends AbstractDockerMojo {
   
   private static String encodeBuildParam(Object buildParam) throws MojoExecutionException {
     try {
-      return URLEncoder.encode(new Gson().toJson(buildParam), "utf-8");
+      return URLEncoder.encode(
+               new Gson().toJson(buildParam), StandardCharsets.UTF_8.toString()
+             ).replace('+', ' ');
     } catch (UnsupportedEncodingException e) {
       throw new MojoExecutionException("Could not build image", e);
     }


### PR DESCRIPTION
If a build argument contains the space character, that's replaced by the `+` character.

This is due to https://github.com/spotify/dockerfile-maven/blob/986f960cb82085d2f666acd6c2682672d47f5bb0/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java#L291-L297 that encodes build arguments using `URLEncoder`. Indeed, we can read [here](https://docs.oracle.com/javase/7/docs/api/java/net/URLEncoder.html) that `URLEncoder` replaces the space character " " with a plus sign "+".

After the encoding, I added a replace to substitute the `+` sign with a space: after the encoding all the plus signs will be already encoded to `/0x2B`, so the ones left are the ones are coming from spaces.

I expanded the test case to make sure that everything will continue to work in the future.
Let me know if you need additional info.

Fixes #136 
Fixes #286