### PR TITLE
fix of the cacheFrom parameter issue while mapping to the docker api …

### DIFF
--- a/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
+++ b/plugin/src/main/java/com/spotify/plugin/dockerfile/BuildMojo.java
@@ -212,7 +212,7 @@ public class BuildMojo extends AbstractDockerMojo {
         }
       }
       if (!cacheFromExistLocally.isEmpty()) {
-        buildParameters.add(new DockerClient.BuildParam("cache-from",
+        buildParameters.add(new DockerClient.BuildParam("cachefrom",
                 encodeBuildParam(cacheFromExistLocally)));
       }
     }


### PR DESCRIPTION
invalid mapping prevents plugin to consume cache-from parameter of docker correctly